### PR TITLE
feat: add loadBalancerClass support for everest server service

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -225,7 +225,8 @@ The following table shows the configurable parameters of the OpenEverest chart a
 | server.rbac.enabled | bool | `false` | If set, enables RBAC for Everest. |
 | server.rbac.policy | string | `"g, admin, role:admin\n"` | RBAC policy configuration. Ignored if `rbac.enabled` is false. |
 | server.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"20Mi"}}` | Resources to allocate for the server container. |
-| server.service | object | `{"name":"everest","port":8080,"type":"ClusterIP"}` | Service configuration for the server. |
+| server.service | object | `{"loadBalancerClass":"","name":"everest","port":8080,"type":"ClusterIP"}` | Service configuration for the server. |
+| server.service.loadBalancerClass | string | `""` | LoadBalancer class for the service. Only applies when `service.type=LoadBalancer`. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class |
 | server.service.name | string | `"everest"` | Name of the service for everest |
 | server.service.port | int | `8080` | Port to expose on the service. If `tls.enabled=true`, then the service is exposed on port 443. |
 | server.service.type | string | `"ClusterIP"` | Type of service to create. |

--- a/charts/everest/templates/everest-server/service.yaml
+++ b/charts/everest/templates/everest-server/service.yaml
@@ -11,6 +11,9 @@ spec:
     app.kubernetes.io/name: everest-server
     app.kubernetes.io/component: everest-server
   type: {{ .Values.server.service.type }}
+  {{- if .Values.server.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.server.service.loadBalancerClass }}
+  {{- end }}
   ports:
     - protocol: TCP
       {{- if .Values.server.tls.enabled }}

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -46,6 +46,9 @@ server:
     # -- Port to expose on the service.
     # If `tls.enabled=true`, then the service is exposed on port 443.
     port: 8080
+    # -- LoadBalancer class for the service. Only applies when `service.type=LoadBalancer`.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+    loadBalancerClass: ""
   # -- Key for signing JWT tokens. This needs to be an RSA private key.
   # This is created during installation only.
   # To update the key after installation, you need to manually update the `everest-jwt` Secret or use everestctl.


### PR DESCRIPTION
Adds optional loadBalancerClass field to server.service in values.yaml. The field is only rendered in the Service manifest when set, maintaining backwards compatibility with existing deployments.

<img width="1818" height="484" alt="image" src="https://github.com/user-attachments/assets/0589a685-2fb7-41d6-904f-101bc4732623" />

Fixes #12 