### PR TITLE
Add Gateway API HTTPRoute support as alternative to ingress

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -176,6 +176,12 @@ The following table shows the configurable parameters of the OpenEverest chart a
 | dataImporters.perconaPXCOperator.enabled | bool | `true` | If set, installs the Percona PXC Operator data importer. |
 | dbNamespace.enabled | bool | `true` | If set, deploy the database operators in `everest` namespace. The namespace may be overridden by setting `dbNamespace.namespaceOverride`. |
 | dbNamespace.namespaceOverride | string | `"everest"` | If `dbNamespace.enabled` is `true`, deploy the database operators in this namespace. |
+| gatewayAPI | object | `{"annotations":{},"enabled":false,"hostnames":[],"parentRefs":[],"rules":[]}` | Configuration for Gateway API (alternative to ingress). Requires a Gateway API implementation (e.g., Kong, Traefik, Istio, Envoy Gateway, AWS/GCP). |
+| gatewayAPI.annotations | object | `{}` | Additional annotations for the HTTPRoute resource. |
+| gatewayAPI.enabled | bool | `false` | Enable Gateway API HTTPRoute for Everest server. |
+| gatewayAPI.hostnames | list | `[]` | Hostnames for the HTTPRoute. If empty, matches all hostnames on the parent Gateway. |
+| gatewayAPI.parentRefs | list | `[]` | Parent Gateway references. At least one is required when enabled. Each entry references an existing Gateway that should route traffic to Everest. |
+| gatewayAPI.rules | list | `[]` | Routing rules. If empty, a default catch-all rule routing to the Everest service is created. |
 | hooks | object | `{"image":"percona/everest-helmtools:0.0.1","lbcCleanup":{},"pspCleanup":{},"upgradeChecks":{"image":"ghcr.io/openeverest/everestctl"}}` | Configuration for Helm chart hooks. |
 | hooks.image | string |  | Default image to use for the Helm chart hooks job. |
 | hooks.lbcCleanup | object | `{}` | Configuration for LoadBalancerConfig clean-up hook. |

--- a/charts/everest/templates/everest-server/httproute.yaml
+++ b/charts/everest/templates/everest-server/httproute.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.gatewayAPI.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "chart.fullname" . }}
+  namespace: {{ include "everest.namespace" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.gatewayAPI.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+      {{- if .port }}
+      port: {{ .port }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.gatewayAPI.rules }}
+    {{- range .Values.gatewayAPI.rules }}
+    - matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type | default "PathPrefix" }}
+            value: {{ .path.value | default "/" }}
+          {{- if .headers }}
+          headers:
+            {{- toYaml .headers | nindent 12 }}
+          {{- end }}
+          {{- if .method }}
+          method: {{ .method }}
+          {{- end }}
+        {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $.Values.server.service.name }}
+          port: {{ $.Values.server.service.port }}
+    {{- end }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ .Values.server.service.name }}
+          port: {{ .Values.server.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/everest/test/test-values.yaml
+++ b/charts/everest/test/test-values.yaml
@@ -99,6 +99,22 @@ ingress:
       hosts:
         - everest.example.com
 
+gatewayAPI:
+  enabled: true
+  annotations:
+    example.com/owner: everest
+  parentRefs:
+    - name: main-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - everest.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
 dataImporters:
   perconaPGOperator:
     enabled: true

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -305,6 +305,28 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+# -- Configuration for Gateway API (alternative to ingress).
+# Requires a Gateway API implementation (e.g., Kong, Traefik, Istio, Envoy Gateway, AWS/GCP).
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute for Everest server.
+  enabled: false
+  # -- Additional annotations for the HTTPRoute resource.
+  annotations: {}
+  # -- Parent Gateway references. At least one is required when enabled.
+  # Each entry references an existing Gateway that should route traffic to Everest.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # -- Hostnames for the HTTPRoute. If empty, matches all hostnames on the parent Gateway.
+  hostnames: []
+  #  - everest.example.com
+  # -- Routing rules. If empty, a default catch-all rule routing to the Everest service is created.
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /
 # Do not change the following values unless you know what you are doing.
 # @ignore
 monitoring:


### PR DESCRIPTION
Fixes #5

Adds Kubernetes Gateway API support via `HTTPRoute`, giving users a controller-agnostic alternative to the existing `ingress` configuration.


### Configuration

```yaml
gatewayAPI:
  enabled: false
  annotations: {}
  parentRefs: []
  hostnames: []
  rules: []
```

### Compatibility

| Gateway Implementation | Supported |
|------------------------|-----------|
| Kong | Yes |
| Traefik | Yes |
| Istio | Yes |
| Envoy Gateway | Yes |
| AWS Gateway API Controller | Yes |
| GCP Gateway Controller | Yes |

Both `ingress` and `gatewayAPI` can be enabled independently. TLS is handled at the Gateway listener level via `parentRefs.sectionName`.