### PR TITLE
Hub as dependency

### DIFF
--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 1.14.0
 - name: plugin-hub
   repository: oci://ghcr.io/openeverest/charts
-  version: 0.1.9
-digest: sha256:5875218099d23d6a5814150b4a3644b0acf493c322a7bdd92901fd2455e302b4
-generated: "2026-06-30T16:10:16.885085+07:00"
+  version: 0.1.10
+digest: sha256:b4d4fa6cd06c6304ceed5e0f3d2f8734e419372e713bed2e68ec6212bc7b6467
+generated: "2026-07-02T10:39:13.047589+07:00"

--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 1.14.0
 - name: plugin-hub
   repository: oci://ghcr.io/openeverest/charts
-  version: 0.1.10
-digest: sha256:b4d4fa6cd06c6304ceed5e0f3d2f8734e419372e713bed2e68ec6212bc7b6467
-generated: "2026-07-02T10:39:13.047589+07:00"
+  version: 0.1.11
+digest: sha256:5c65dc11f3deacce19aa58ecaf6072dc3259b70a7ba2ffaaec8b91e0eb691ac4
+generated: "2026-07-02T10:57:30.293435+07:00"

--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -17,5 +17,8 @@ dependencies:
 - name: everest-crds
   repository: file://charts/everest-crds
   version: 1.14.0
-digest: sha256:8bfb07f789fe4bda1999519f97095bd2ea78d2fed1eab7eca1170254e88eefd2
-generated: "2026-05-22T15:04:15.245748343+01:00"
+- name: plugin-hub
+  repository: oci://ghcr.io/openeverest/charts
+  version: 0.1.9
+digest: sha256:5875218099d23d6a5814150b4a3644b0acf493c322a7bdd92901fd2455e302b4
+generated: "2026-06-30T16:10:16.885085+07:00"

--- a/charts/everest/Chart.yaml
+++ b/charts/everest/Chart.yaml
@@ -47,4 +47,4 @@ dependencies:
   - name: plugin-hub
     repository: "oci://ghcr.io/openeverest/charts"
     condition: "plugins.hub.enabled"
-    version: "0.1.9"
+    version: "0.1.10"

--- a/charts/everest/Chart.yaml
+++ b/charts/everest/Chart.yaml
@@ -44,3 +44,7 @@ dependencies:
     repository: "file://charts/everest-crds"
     condition: "everest-crds.enabled"
     version: "1.14.0"
+  - name: plugin-hub
+    repository: "oci://ghcr.io/openeverest/charts"
+    condition: "plugins.hub.enabled"
+    version: "0.1.9"

--- a/charts/everest/Chart.yaml
+++ b/charts/everest/Chart.yaml
@@ -47,4 +47,4 @@ dependencies:
   - name: plugin-hub
     repository: "oci://ghcr.io/openeverest/charts"
     condition: "plugins.hub.enabled"
-    version: "0.1.10"
+    version: "0.1.11"

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -287,6 +287,18 @@ pmm3:
   # -- PMM configuration. All PMM chart values go under this key.
   pmm:
     nameOverride: pmm3
+# -- Configuration for OpenEverest plugins bundled with this chart.
+plugins:
+  # -- Plugin Hub settings.
+  hub:
+    # -- If set, deploys the OpenEverest Plugin Hub (`plugin-hub` sub-chart)
+    # in the release namespace alongside Everest. Disable with
+    # `--set plugins.hub.enabled=false`.
+    enabled: true
+# -- Values forwarded to the `plugin-hub` sub-chart.
+# Refer to the upstream chart for the full list of configurable values:
+# https://ghcr.io/openeverest/charts/plugin-hub
+plugin-hub: {}
 # DO NOT CHANGE.
 # We set this to `false` to prevent the CRDs from being rendered as a template.
 # The CRDs are already installed as a part of the crds/ directory via the sub-chart.


### PR DESCRIPTION
This change adds the plugin-hub as a dependency. It installs it alogn with a helm chart, but users can disable it. 

Signed-off-by: Sergey Pronin <sp@solanica.io>