### PR TITLE
feat : expose httpProxy/httpsProxy/noProxy for Helm chart hook Jobs

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -182,6 +182,9 @@ The following table shows the configurable parameters of the OpenEverest chart a
 | gatewayAPI.hostnames | list | `[]` | Hostnames for the HTTPRoute. If empty, matches all hostnames on the parent Gateway. |
 | gatewayAPI.parentRefs | list | `[]` | Parent Gateway references. At least one is required when enabled. Each entry references an existing Gateway that should route traffic to Everest. |
 | gatewayAPI.rules | list | `[]` | Routing rules. If empty, a default catch-all rule routing to the Everest service is created. |
+| global.httpProxy | string | `""` | HTTP proxy URL injected as HTTP_PROXY into all Helm chart hook job containers. |
+| global.httpsProxy | string | `""` | HTTPS proxy URL injected as HTTPS_PROXY into all Helm chart hook job containers. |
+| global.noProxy | string | `""` | Comma-separated list of hosts to exclude from proxying, injected as NO_PROXY into all Helm chart hook job containers. Since some hook jobs call kubectl against the in-cluster API server, include its address/CIDR here if it would otherwise be proxied. |
 | hooks | object | `{"image":"percona/everest-helmtools:0.0.1","lbcCleanup":{},"pspCleanup":{},"upgradeChecks":{"image":"ghcr.io/openeverest/everestctl"}}` | Configuration for Helm chart hooks. |
 | hooks.image | string |  | Default image to use for the Helm chart hooks job. |
 | hooks.lbcCleanup | object | `{}` | Configuration for LoadBalancerConfig clean-up hook. |

--- a/charts/everest/charts/common/templates/_csv_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_csv_cleanup.yaml.tpl
@@ -1,6 +1,7 @@
 #
 # @param .namespace     The namespace where the operator is installed
 # @param .image         The image to use for running the hook Job
+# @param .global        Global values, e.g. httpProxy/httpsProxy/noProxy
 #
 {{- define "everest.csvCleanup" }}
 {{- $hookName := printf "everest-helm-pre-delete-hook" }}
@@ -68,6 +69,19 @@ spec:
             - |
               kubectl delete subscription -n {{ .namespace }} --all --wait
               kubectl delete csv -n {{ .namespace }} --all --wait
+          env:
+            {{- if .global.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .global.httpProxy | quote }}
+            {{- end }}
+            {{- if .global.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .global.httpsProxy | quote }}
+            {{- end }}
+            {{- if .global.noProxy }}
+            - name: NO_PROXY
+              value: {{ .global.noProxy | quote }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: {{ $hookName }}

--- a/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
@@ -1,6 +1,7 @@
 #
 # @param .namespace     The namespace where DB and its resources are deployed
 # @param .image         The image to use for running the hook Job
+# @param .global        Global values, e.g. httpProxy/httpsProxy/noProxy
 #
 {{- define "everest.dbResourcesCleanup" }}
 {{- $hookName := printf "everest-helm-pre-delete-db-resource-cleanup" }}
@@ -82,6 +83,19 @@ spec:
                 
               echo "Deleting MonitoringConfigs"
               kubectl delete monitoringconfigs -n {{ .namespace }} --all --wait
+          env:
+            {{- if .global.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .global.httpProxy | quote }}
+            {{- end }}
+            {{- if .global.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .global.httpsProxy | quote }}
+            {{- end }}
+            {{- if .global.noProxy }}
+            - name: NO_PROXY
+              value: {{ .global.noProxy | quote }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: {{ $hookName }}

--- a/charts/everest/charts/common/templates/_lbc_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_lbc_cleanup.yaml.tpl
@@ -2,6 +2,7 @@
 #
 # @param .namespace     The namespace where Everest server is installed
 # @param .image         The image to use for running the hook Job
+# @param .global        Global values, e.g. httpProxy/httpsProxy/noProxy
 #
 {{- define "everest.lbcCleanup" }}
 {{- $hookName := printf "everest-helm-lbc-cleanup-hook" }}
@@ -74,6 +75,19 @@ spec:
                 kubectl patch $lbc -p '{"metadata":{"finalizers":[]}}' --type=merge || true
                 kubectl delete $lbc || true
               done
+          env:
+            {{- if .global.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .global.httpProxy | quote }}
+            {{- end }}
+            {{- if .global.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .global.httpsProxy | quote }}
+            {{- end }}
+            {{- if .global.noProxy }}
+            - name: NO_PROXY
+              value: {{ .global.noProxy | quote }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: {{ $hookName }}

--- a/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
+++ b/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
@@ -1,6 +1,7 @@
 #
 # @param .namespace     The namespace where the operators are installed
 # @param .image         The image to use for running the hook Job
+# @param .global        Global values, e.g. httpProxy/httpsProxy/noProxy
 #
 {{- define "everest.operatorsInstaller" }}
 {{- $hookName := "everest-operators-installer" }}
@@ -114,6 +115,19 @@ spec:
                 echo "Waiting for CSV $csv to succeed"
                 kubectl wait --for=jsonpath='.status.phase'=Succeeded clusterserviceversions.operators.coreos.com/$csv -n {{ .namespace }} --timeout=600s
               done
+          env:
+            {{- if .global.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .global.httpProxy | quote }}
+            {{- end }}
+            {{- if .global.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .global.httpsProxy | quote }}
+            {{- end }}
+            {{- if .global.noProxy }}
+            - name: NO_PROXY
+              value: {{ .global.noProxy | quote }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: {{ $hookName }}

--- a/charts/everest/charts/common/templates/_psp_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_psp_cleanup.yaml.tpl
@@ -2,6 +2,7 @@
 #
 # @param .namespace     The namespace where Everest server is installed
 # @param .image         The image to use for running the hook Job
+# @param .global        Global values, e.g. httpProxy/httpsProxy/noProxy
 #
 {{- define "everest.pspCleanup" }}
 {{- $hookName := printf "everest-helm-psp-cleanup-hook" }}
@@ -75,6 +76,19 @@ spec:
                 kubectl patch podschedulingpolicy/$pspName -p '{"metadata":{"finalizers":[]}}' --type=merge
                 kubectl delete $pspName
               done
+          env:
+            {{- if .global.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .global.httpProxy | quote }}
+            {{- end }}
+            {{- if .global.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .global.httpsProxy | quote }}
+            {{- end }}
+            {{- if .global.noProxy }}
+            - name: NO_PROXY
+              value: {{ .global.noProxy | quote }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       serviceAccount: {{ $hookName }}

--- a/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
+++ b/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
@@ -3,6 +3,7 @@
 # @param .version               Version to upgrade to
 # @param .versionMetadataURL    The URL of the version metadata service
 # @param .image                 The image to use for running the hook Job
+# @param .global                Global values, e.g. httpProxy/httpsProxy/noProxy
 #
 {{- define "everest.preUpgradeChecks" }}
 {{- $hookName := printf "everest-helm-pre-upgrade-hook" }}
@@ -107,6 +108,19 @@ spec:
             - |
               echo "Checking requirements for upgrade to version {{ .version }}"
               everestctl upgrade --in-cluster --dry-run --version-metadata-url={{ .versionMetadataURL }} --kubeconfig=""
+          env:
+            {{- if .global.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .global.httpProxy | quote }}
+            {{- end }}
+            {{- if .global.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .global.httpsProxy | quote }}
+            {{- end }}
+            {{- if .global.noProxy }}
+            - name: NO_PROXY
+              value: {{ .global.noProxy | quote }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 30

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -27,6 +27,9 @@ Kubernetes: `>= 1.27.0-0`
 |-----|------|---------|-------------|
 | cleanupOnUninstall | bool | `true` | If set, cleans up the DB resources on uninstall. |
 | compatibility.openshift | bool | `false` | If set, enable OpenShift compatibility. |
+| global.httpProxy | string | `""` | HTTP proxy URL injected as HTTP_PROXY into all Helm chart hook job containers. |
+| global.httpsProxy | string | `""` | HTTPS proxy URL injected as HTTPS_PROXY into all Helm chart hook job containers. |
+| global.noProxy | string | `""` | Comma-separated list of hosts to exclude from proxying, injected as NO_PROXY into all Helm chart hook job containers. Since some hook jobs call kubectl against the in-cluster API server, include its address/CIDR here if it would otherwise be proxied. |
 | hooks | object | `{"csvCleanup":{},"dbResourcesCleanup":{},"image":"percona/everest-helmtools:0.0.1","operatorsInstaller":{}}` | Configuration for Helm chart hooks. |
 | hooks.csvCleanup | object | `{}` | Configuration for the ClusterServiceVersion cleanup hook. |
 | hooks.dbResourcesCleanup | object | `{}` | Configuration for the DB resources cleanup hook. |

--- a/charts/everest/charts/everest-db-namespace/templates/hooks.yaml
+++ b/charts/everest/charts/everest-db-namespace/templates/hooks.yaml
@@ -1,7 +1,7 @@
-{{- include "everest.csvCleanup" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.csvCleanup.image | default .Values.hooks.image)) }}
+{{- include "everest.csvCleanup" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.csvCleanup.image | default .Values.hooks.image) "global" .Values.global) }}
 ---
-{{- include "everest.operatorsInstaller" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.operatorsInstaller.image | default .Values.hooks.image)) }}
+{{- include "everest.operatorsInstaller" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.operatorsInstaller.image | default .Values.hooks.image) "global" .Values.global) }}
 ---
 {{ if .Values.cleanupOnUninstall }}
-{{- include "everest.dbResourcesCleanup" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.dbResourcesCleanup.image | default .Values.hooks.image)) }}
+{{- include "everest.dbResourcesCleanup" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.dbResourcesCleanup.image | default .Values.hooks.image) "global" .Values.global) }}
 {{- end }}

--- a/charts/everest/charts/everest-db-namespace/values.yaml
+++ b/charts/everest/charts/everest-db-namespace/values.yaml
@@ -20,6 +20,15 @@ hooks:
     # If not set, uses the value of `hooks.image`.
     # image: ""
 
+global:
+  # -- HTTP proxy URL injected as HTTP_PROXY into all Helm chart hook job containers.
+  httpProxy: ""
+  # -- HTTPS proxy URL injected as HTTPS_PROXY into all Helm chart hook job containers.
+  httpsProxy: ""
+  # -- Comma-separated list of hosts to exclude from proxying, injected as NO_PROXY into
+  # all Helm chart hook job containers. Since some hook jobs call kubectl against the
+  # in-cluster API server, include its address/CIDR here if it would otherwise be proxied.
+  noProxy: ""
 compatibility:
   # -- If set, enable OpenShift compatibility.
   openshift: false

--- a/charts/everest/templates/hooks.yaml
+++ b/charts/everest/templates/hooks.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.upgrade.preflightChecks }}
-{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "version" .Chart.AppVersion "versionMetadataURL" (include "everest.versionMetadataURL" .) "image" .Values.hooks.upgradeChecks.image) }}
+{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "version" .Chart.AppVersion "versionMetadataURL" (include "everest.versionMetadataURL" .) "image" .Values.hooks.upgradeChecks.image "global" .Values.global) }}
 {{- end }}
 ---
 {{- /*
@@ -12,8 +12,8 @@
 {{- end }}
 
 {{- /* #  Cleanup all default pod scheduling policies during uninstall. */}}
-{{- include "everest.pspCleanup" (dict "namespace" (include "everest.namespace" .) "image" (.Values.hooks.pspCleanup.image | default .Values.hooks.image)) }}
+{{- include "everest.pspCleanup" (dict "namespace" (include "everest.namespace" .) "image" (.Values.hooks.pspCleanup.image | default .Values.hooks.image) "global" .Values.global) }}
 
 {{- /* #  Cleanup all default load balancer configs during uninstall. */}}
-{{- include "everest.lbcCleanup" (dict "namespace" (include "everest.namespace" .) "image" (.Values.hooks.lbcCleanup.image | default .Values.hooks.image)) }}
+{{- include "everest.lbcCleanup" (dict "namespace" (include "everest.namespace" .) "image" (.Values.hooks.lbcCleanup.image | default .Values.hooks.image) "global" .Values.global) }}
 ---

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -18,6 +18,15 @@ hooks:
     # -- Image for the upgrade checks hook job.
     # This image must have everestctl pre-installed to support air-gapped environments.
     image: "ghcr.io/openeverest/everestctl"
+global:
+  # -- HTTP proxy URL injected as HTTP_PROXY into all Helm chart hook job containers.
+  httpProxy: ""
+  # -- HTTPS proxy URL injected as HTTPS_PROXY into all Helm chart hook job containers.
+  httpsProxy: ""
+  # -- Comma-separated list of hosts to exclude from proxying, injected as NO_PROXY into
+  # all Helm chart hook job containers. Since some hook jobs call kubectl against the
+  # in-cluster API server, include its address/CIDR here if it would otherwise be proxied.
+  noProxy: ""
 compatibility:
   # -- Enable OpenShift compatibility.
   openshift: false


### PR DESCRIPTION
Adds `global.httpProxy`, `global.httpsProxy`, and `global.noProxy` values and
injects them as `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars into all hook
Job containers (upgrade checks, PSP cleanup, LBC cleanup, CSV cleanup,
operators installer, DB resources cleanup), so hook jobs can run in
environments that require an HTTP proxy for outbound requests.

 other asks from #10  issue (configurable kubectl/upgrade
image, and removing the runtime curl/apk download) are already resolved by
prior work (`hooks.image` + per-hook overrides, and the pre-built
`everestctl` image), per the maintainer's scoping comment on the issue.

Since `common` is a library chart with no values of its own, `global.*` is
declared in each installable chart's values.yaml (`everest` and
`everest-db-namespace`) and threaded through the existing hook `include`
calls, rather than in `common/values.yaml` (which is unused).

Env vars are omitted entirely when unset, so this is a no-op by default.

Tested with `helm lint` and `helm template` (with and without proxy values
set) on both `everest` and standalone `everest-db-namespace`.

Closes #10
