### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs (v2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.14.0
 
@@ -35,7 +35,7 @@ jobs:
         run: helm lint charts/everest --namespace everest-system
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
       - name: Run ct lint
         run: |
@@ -48,12 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.14.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.branch }}
           sparse-checkout: |
@@ -49,17 +49,17 @@ jobs:
           make release
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
         with:
           version: v3.4.0
 
       - name: Release chart
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Release sub-chart
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         with:
           charts_dir: charts/everest/charts
           skip_existing: true


### PR DESCRIPTION
## Why

Actions must now be pinned to full-length commit SHAs at the org level. A mutable tag means the action's owner — or anyone who compromises them — can change what executes in our pipelines retroactively, and unpinned workflows no longer run.

This is the `v2` counterpart to #79, which does the same on `main`. `v2` is an active parallel branch (48 commits ahead of `main`), so it needs the change independently — otherwise its CI and release workflows stop running.

## What

Every `uses:` tag reference is replaced with the commit SHA that tag points at today, keeping the human-readable version in a trailing comment:

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
```

9 references across 2 workflows (`ci.yaml`, `release.yaml`):

| Action | Pinned to |
|---|---|
| `actions/checkout` | `11d5960a` # v4.4.0 |
| `azure/setup-helm` | `1a275c3b` # v4.3.1 |
| `azure/setup-helm` | `18bc7681` # v1.1 |
| `helm/chart-testing-action` | `e6669bcd` # v2.6.1 |
| `helm/chart-releaser-action` | `a917fd15` # v1.6.0 |

- **Behaviour-preserving** — same code runs, it just can't change underneath us.
- Annotated tags were dereferenced to the underlying commit.
- Comments use the most specific release tag pointing at that commit (`v4.4.0` rather than `v4`).
- Line-for-line; +9/-9, no reordering or reformatting.

Generated mechanically and YAML-validated. Part of an org-wide sweep across all repositories.

## Note

`release.yaml` still uses `azure/setup-helm` **v1** while `ci.yaml` is on **v4**. Pinned as-is here to keep this diff behaviour-preserving, but worth aligning separately.
