### PR TITLE
ci: declare token permissions (fixes release workflow under read-only default)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'charts/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ on:
         default: main
         description: "Branch to checkout for chart release"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     env:


### PR DESCRIPTION
## Why

`release.yaml` runs `helm/chart-releaser-action` with `CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. chart-releaser **creates GitHub Releases and pushes the index to `gh-pages`**, both of which need `contents: write`.

The org-level default for `GITHUB_TOKEN` was changed to **read repository contents**, and this workflow has no `permissions:` block — so it inherits `read` and **will fail on its next run**. It only triggers on `workflow_dispatch`, so the failure won't surface until someone cuts a chart release.

## Changes

| Workflow | Permission | Reason |
|---|---|---|
| `release.yaml` | `contents: write` | chart-releaser creates releases + pushes to `gh-pages` |
| `ci.yaml` | `contents: read` | lint/test only; no token writes |

## Also worth a look (not changed here)

`ci.yaml` and `release.yaml` pin `azure/setup-helm` at **two different versions in the same repo**:

```
azure/setup-helm@18bc7681... # v1.1
azure/setup-helm@1a275c3b... # v4.3.1
```

v1.1 is three majors behind and long unsupported. Left alone to keep this diff focused, but worth its own PR — this repo has no `dependabot.yml`, so nothing will converge them automatically.
