### PR TITLE
fix: override PMM3 security context for OpenShift compatibility

### DIFF
--- a/charts/everest/Makefile
+++ b/charts/everest/Makefile
@@ -87,6 +87,11 @@ docs-gen:
 test:
 	$(HELM) template test . --namespace everest-system
 	$(HELM) template test . --namespace everest-system -f test/test-values.yaml
+	$(MAKE) test-pmm3
+
+.PHONY: test-pmm3
+test-pmm3:
+	HELM=$(HELM) bash ./charts/pmm3/test/assert-openshift-scc.sh
 
 .PHONY: link-crds
 link-crds:

--- a/charts/everest/charts/pmm3/implementation.md
+++ b/charts/everest/charts/pmm3/implementation.md
@@ -1,0 +1,42 @@
+# PMM3 OpenShift Security Context
+
+## Background
+
+- Issue: openeverest/helm-charts#70 — PMM3 deploys fail on OpenShift.
+- The upstream `percona/pmm` chart (v1.4.14) hardcodes `runAsUser`,
+  `runAsGroup` and `fsGroup` to `1000` in `podSecurityContext`.
+  OpenShift's restricted SCC rejects any pod that pins a UID outside the
+  namespace's assigned range, so the StatefulSet never schedules.
+- The wrapper (`charts/everest/charts/pmm3`) already nullifies those UIDs
+  (see commit `91830b5`) so OpenShift can assign a random UID instead.
+
+## Why test this
+
+The wrapper depends on values reaching the subchart through the `pmm.*`
+key. If the dependency bumps or the override is accidentally dropped, the
+hardcoded `1000` returns and OpenShift breaks again — silently, until
+someone tries to install there. A template-level assertion catches that
+regression in CI instead of in the field.
+
+## What the test checks
+
+`charts/everest/charts/pmm3/test/assert-openshift-scc.sh` renders the
+wrapper chart and asserts the resulting StatefulSet:
+
+- `runAsUser`, `runAsGroup`, `fsGroup` are absent or null on the pod
+  security context.
+- `runAsNonRoot: true` and `seccompProfile.type: RuntimeDefault` are set.
+- The container drops `ALL` capabilities and sets
+  `allowPrivilegeEscalation: false`.
+
+It uses only `bash` + `python3` stdlib (no PyYAML), so it runs on a stock
+GitHub Actions runner. It is wired into `make test` via the new
+`test-pmm3` Makefile target.
+
+## What is not covered here
+
+Whether PMM actually starts without `runAsUser: 0` — the container writes
+to `/srv` (the PVC mount); if files are root-owned the random non-root UID
+may hit permission errors at startup. That is a runtime question and needs
+a real OpenShift cluster (e.g. CRC) to answer. The template test only
+protects the manifest contract, not the runtime behaviour.

--- a/charts/everest/charts/pmm3/test/assert-openshift-scc.sh
+++ b/charts/everest/charts/pmm3/test/assert-openshift-scc.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Asserts that the pmm3 wrapper chart overrides the upstream PMM security
+# context for OpenShift compatibility.
+#
+# Verifies the rendered StatefulSet:
+#   - does NOT hardcode runAsUser / runAsGroup / fsGroup (SCC-rejected on OCP)
+#   - sets runAsNonRoot: true
+#   - sets seccompProfile.type: RuntimeDefault
+#   - container drops ALL capabilities and disables privilege escalation
+#
+# Uses only python3 stdlib (no PyYAML) so it runs on a stock GitHub runner.
+# Run via: `make -C charts/everest test-pmm3`
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELM="${HELM:-helm}"
+
+manifest="$("$HELM" template test "$CHART_DIR" --namespace pmm)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+which python3 >/dev/null 2>&1 || fail "python3 is required to run this test"
+
+export manifest
+python3 - <<'PY'
+import os, re, sys
+
+manifest = os.environ["manifest"]
+
+# Split rendered manifest into YAML documents and keep the StatefulSet one.
+docs = re.split(r"(?m)^---\s*$", manifest)
+statefulsets = [
+    d for d in docs
+    if re.search(r"(?m)^kind:\s*StatefulSet\s*$", d)
+]
+if not statefulsets:
+    sys.stderr.write("FAIL: no StatefulSet rendered\n")
+    sys.exit(1)
+sts = statefulsets[0]
+
+# Pod securityContext lives immediately under spec.template.spec at 6-space indent:
+#       securityContext:
+#         <2 extra spaces for its children>
+m = re.search(
+    r"(?m)^      securityContext:\n((?:^        .+\n|^$\n)+)",
+    sts,
+)
+if not m:
+    sys.stderr.write("FAIL: no pod securityContext block in StatefulSet\n")
+    sys.exit(1)
+block = m.group(1)
+
+# Hardcoded UIDs must be absent or null so OpenShift SCC can assign them.
+for key in ("runAsUser", "runAsGroup", "fsGroup"):
+    present = re.search(rf"(?m)^        {re.escape(key)}:\s*(.*)$", block)
+    if not present:
+        continue
+    val = present.group(1).strip()
+    if val and val.lower() != "null":
+        sys.stderr.write(
+            f"FAIL: pod securityContext.{key} is set to '{val}'; "
+            "must be absent/null for OpenShift SCC\n"
+        )
+        sys.exit(1)
+
+# runtime hardening must be set.
+if not re.search(r"(?m)^        runAsNonRoot:\s*true\s*$", block):
+    sys.stderr.write("FAIL: pod securityContext.runAsNonRoot must be true\n")
+    sys.exit(1)
+
+# seccompProfile.type: RuntimeDefault
+if not re.search(r"(?m)^        seccompProfile:\n          type: RuntimeDefault\s*$", block):
+    sys.stderr.write("FAIL: pod securityContext.seccompProfile.type must be RuntimeDefault\n")
+    sys.exit(1)
+
+# Container securityContext lives at 10-space indent under the container.
+mc = re.search(
+    r"(?m)^          securityContext:\n((?:^            .+\n|^              .+\n)+)",
+    sts,
+)
+if not mc:
+    sys.stderr.write("FAIL: no container securityContext block in StatefulSet\n")
+    sys.exit(1)
+cb = mc.group(1)
+
+if "ALL" not in cb:
+    sys.stderr.write("FAIL: container does not drop ALL capabilities\n")
+    sys.exit(1)
+
+if not re.search(r"(?m)^            allowPrivilegeEscalation:\s*false\s*$", cb):
+    sys.stderr.write("FAIL: container.allowPrivilegeEscalation must be false\n")
+    sys.exit(1)
+
+print("OK: pmm3 OpenShift security context overrides render as expected")
+PY

--- a/charts/everest/charts/pmm3/values.yaml
+++ b/charts/everest/charts/pmm3/values.yaml
@@ -2,3 +2,20 @@
 # All PMM configuration goes under the 'pmm' key
 pmm:
   nameOverride: pmm3
+  # -- Pod-level security context for the PMM StatefulSet.
+  # We nullify runAsUser, runAsGroup, and fsGroup to drop upstream hardcoded defaults.
+  # This allows OpenShift SCCs to dynamically assign UIDs from the namespace's range.
+  podSecurityContext:
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+    runAsNonRoot: true
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Container-level security context for the PMM container.
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    allowPrivilegeEscalation: false

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -351,6 +351,23 @@ pmm3:
   # -- PMM configuration. All PMM chart values go under this key.
   pmm:
     nameOverride: pmm3
+    # -- Pod-level security context for the PMM StatefulSet.
+    # We nullify runAsUser, runAsGroup, and fsGroup to drop upstream hardcoded defaults.
+    # This allows OpenShift SCCs to dynamically assign UIDs from the namespace's range.
+    podSecurityContext:
+      runAsUser: null
+      runAsGroup: null
+      fsGroup: null
+      runAsNonRoot: true
+      fsGroupChangePolicy: OnRootMismatch
+      seccompProfile:
+        type: RuntimeDefault
+    # -- Container-level security context for the PMM container.
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      allowPrivilegeEscalation: false
 # DO NOT CHANGE.
 # We set this to `false` to prevent the CRDs from being rendered as a template.
 # The CRDs are already installed as a part of the crds/ directory via the sub-chart.


### PR DESCRIPTION
Fixes #70

Nullifies hardcoded runAsUser, runAsGroup, and fsGroup in the PMM3 wrapper values and adds runAsNonRoot: true + RuntimeDefault seccomp profile for OpenShift SCC compliance.