### PR TITLE
fix: use multi-arch GHCR helmtools image for chart hooks

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -182,7 +182,7 @@ The following table shows the configurable parameters of the OpenEverest chart a
 | gatewayAPI.hostnames | list | `[]` | Hostnames for the HTTPRoute. If empty, matches all hostnames on the parent Gateway. |
 | gatewayAPI.parentRefs | list | `[]` | Parent Gateway references. At least one is required when enabled. Each entry references an existing Gateway that should route traffic to Everest. |
 | gatewayAPI.rules | list | `[]` | Routing rules. If empty, a default catch-all rule routing to the Everest service is created. |
-| hooks | object | `{"image":"percona/everest-helmtools:0.0.1","lbcCleanup":{},"pspCleanup":{},"upgradeChecks":{"image":"ghcr.io/openeverest/everestctl"}}` | Configuration for Helm chart hooks. |
+| hooks | object | `{"image":"ghcr.io/openeverest/openeverest-helmtools:0.0.1","lbcCleanup":{},"pspCleanup":{},"upgradeChecks":{"image":"ghcr.io/openeverest/everestctl"}}` | Configuration for Helm chart hooks. |
 | hooks.image | string |  | Default image to use for the Helm chart hooks job. |
 | hooks.lbcCleanup | object | `{}` | Configuration for LoadBalancerConfig clean-up hook. |
 | hooks.pspCleanup | object | `{}` | Configuration for PodSchedulingPolicy clean-up hook. |

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -27,10 +27,10 @@ Kubernetes: `>= 1.27.0-0`
 |-----|------|---------|-------------|
 | cleanupOnUninstall | bool | `true` | If set, cleans up the DB resources on uninstall. |
 | compatibility.openshift | bool | `false` | If set, enable OpenShift compatibility. |
-| hooks | object | `{"csvCleanup":{},"dbResourcesCleanup":{},"image":"percona/everest-helmtools:0.0.1","operatorsInstaller":{}}` | Configuration for Helm chart hooks. |
+| hooks | object | `{"csvCleanup":{},"dbResourcesCleanup":{},"image":"ghcr.io/openeverest/openeverest-helmtools:0.0.1","operatorsInstaller":{}}` | Configuration for Helm chart hooks. |
 | hooks.csvCleanup | object | `{}` | Configuration for the ClusterServiceVersion cleanup hook. |
 | hooks.dbResourcesCleanup | object | `{}` | Configuration for the DB resources cleanup hook. |
-| hooks.image | string | `percona/everest-helmtools:0.0.1` | Default image to use for the Helm chart hooks job. |
+| hooks.image | string | `ghcr.io/openeverest/openeverest-helmtools:0.0.1` | Default image to use for the Helm chart hooks job. |
 | hooks.operatorsInstaller | object | `{}` | Configuration for the operators installer hook. |
 | namespaceOverride | string | `""` | Namespace override. Defaults to the value of .Release.Namespace. |
 | postgresql | bool | `true` | If set, installs the Percona Postgresql Server operator. |

--- a/charts/everest/charts/everest-db-namespace/values.yaml
+++ b/charts/everest/charts/everest-db-namespace/values.yaml
@@ -1,8 +1,8 @@
 # -- Configuration for Helm chart hooks.
 hooks:
   # -- Default image to use for the Helm chart hooks job.
-  # @default -- `percona/everest-helmtools:0.0.1`
-  image: "percona/everest-helmtools:0.0.1"
+  # @default -- `ghcr.io/openeverest/openeverest-helmtools:0.0.1`
+  image: "ghcr.io/openeverest/openeverest-helmtools:0.0.1"
   # -- Configuration for the ClusterServiceVersion cleanup hook.
   csvCleanup: {}
     # Image to use for the hook job.

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -1,8 +1,8 @@
 # -- Configuration for Helm chart hooks.
 hooks:
   # -- Default image to use for the Helm chart hooks job.
-  # @default -- `percona/everest-helmtools:0.0.1`
-  image: "percona/everest-helmtools:0.0.1"
+  # @default -- `ghcr.io/openeverest/openeverest-helmtools:0.0.1`
+  image: "ghcr.io/openeverest/openeverest-helmtools:0.0.1"
   # -- Configuration for PodSchedulingPolicy clean-up hook.
   pspCleanup: {}
   # Image to use for the hook job.


### PR DESCRIPTION
Part of openeverest/openeverest#2603 (follow-up comments) / companion to openeverest/openeverest#2929.

`percona/everest-helmtools:0.0.1` ships `linux/amd64` only, so the chart hook jobs (`everest-operators-installer`, CSV/DB-resources cleanup) fail on arm64 hosts with `exec format error`.

This points the `hooks.image` default (everest + everest-db-namespace charts) at `ghcr.io/openeverest/openeverest-helmtools:0.0.1`, the multi-arch (amd64+arm64) image produced by the reworked `release-helmtools` workflow. READMEs regenerated with `make docs-gen`.

**Do not merge before** openeverest/openeverest#2929 is merged and the `release-helmtools` workflow has been dispatched with version `0.0.1`, so the tag exists on GHCR.

Until this lands in a chart release, 1.16.2 users can override without any release:
`everestctl install --helm.set 'hooks.image=ghcr.io/openeverest/openeverest-helmtools:0.0.1'` (same flag on `namespaces add/update` and `upgrade`).
