### PR TITLE
fix: use multi-arch GHCR helmtools image for chart hooks (v2)

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -127,10 +127,10 @@ The following table shows the configurable parameters of the OpenEverest chart a
 | controller.webhook.certs | object | `{"ca.crt":"","tls.crt":"","tls.key":""}` | Certificates to use for the webhook server. The values must be base64 encoded. If unset, uses self-signed certificates. |
 | controller.webhook.preserveTLSCerts | bool |  | If set to true, preserves existing TLS Certificate Secrets during upgrades. This setting is ignored if certificates are explicitly provided in controller.webhook.certs, in which case the specified certificates are used instead. This setting has no effect during installation. |
 | createMonitoringResources | bool | `true` | If set, creates resources for Kubernetes monitoring. |
-| hooks | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"percona/everest-helmtools","tag":"0.0.1"},"upgradeChecks":{"image":{"repository":"","tag":""}}}` | Configuration for Helm chart hooks. |
-| hooks.image | object | `{"pullPolicy":"IfNotPresent","repository":"percona/everest-helmtools","tag":"0.0.1"}` | Default image to use for the Helm chart hooks job. |
+| hooks | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/openeverest/openeverest-helmtools","tag":"0.0.1"},"upgradeChecks":{"image":{"repository":"","tag":""}}}` | Configuration for Helm chart hooks. |
+| hooks.image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/openeverest/openeverest-helmtools","tag":"0.0.1"}` | Default image to use for the Helm chart hooks job. |
 | hooks.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the hooks image. |
-| hooks.image.repository | string | `"percona/everest-helmtools"` | Repository for the hooks image. |
+| hooks.image.repository | string | `"ghcr.io/openeverest/openeverest-helmtools"` | Repository for the hooks image. |
 | hooks.image.tag | string | `"0.0.1"` | Tag for the hooks image. |
 | hooks.upgradeChecks | object | `{"image":{"repository":"","tag":""}}` | Configuration for the upgrade checks hook. |
 | hooks.upgradeChecks.image.repository | string | `""` | Repository for the upgrade checks image. Defaults to `hooks.image.repository` if not set. |

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -3,7 +3,7 @@ hooks:
   # -- Default image to use for the Helm chart hooks job.
   image:
     # -- Repository for the hooks image.
-    repository: "percona/everest-helmtools"
+    repository: "ghcr.io/openeverest/openeverest-helmtools"
     # -- Tag for the hooks image.
     tag: "0.0.1"
     # -- Pull policy for the hooks image.


### PR DESCRIPTION
v2 counterpart of #88 / companion to openeverest/openeverest#2929 (see openeverest/openeverest#2603 follow-up comments).

On v2 the operators-installer/cleanup hooks are gone, but the pre-upgrade-checks hook still runs the amd64-only `percona/everest-helmtools:0.0.1`. This points `hooks.image.repository` at the multi-arch `ghcr.io/openeverest/openeverest-helmtools`. README regenerated with helm-docs.

**Do not merge before** openeverest/openeverest#2929 is merged and the `release-helmtools` workflow has been dispatched with version `0.0.1`, so the tag exists on GHCR.
